### PR TITLE
ci : container registry 주소를 .env 파일로 관리하도록 수정

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -18,8 +18,8 @@ on:
 
 env:
   ROOT_DIR: ~/camfia
-  BACKEND_IMAGE: "${{ secrets.REGISTRY }}/${{ secrets.REGISTRY_USERNAME }}/backend"
-  NGINX_IMAGE: "${{ secrets.REGISTRY }}/${{ secrets.REGISTRY_USERNAME }}/nginx"
+  BACKEND_IMAGE: "${{ secrets.REGISTRY }}/${{ secrets.REGISTRY_REPO }}/backend"
+  NGINX_IMAGE: "${{ secrets.REGISTRY }}/${{ secrets.REGISTRY_REPO }}/nginx"
   GIT_BRANCH: ${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -204,13 +204,15 @@ DOCKER_BUILDKIT=1 docker build -t camfia/nginx ./frontend
 ```
 
 ## 배포 이미지 관리
-[treescale](https://treescale.com/) private container repository로 다음 2개의 배포 이미지가 관리됩니다.
-- repo.treescale.com/camfia/backend
-- repo.treescale.com/camfia/nginx
+다음 2개의 배포 이미지가 관리됩니다.
+- ${REGISTRY}/camfia/backend
+- ${REGISTRY}/camfia/nginx
 
 이미지를 push 또는 pull하기 위해서는 docker login이 필요합니다.
 ```sh
-docker login repo.treescale.com -u camfia
+docker login ${REGISTRY}
+Username:
+Password:
 ```
 
 <br>
@@ -401,6 +403,7 @@ project의 다음 파일을 복사합니다.
 
 이때, docker compose와 certbot을 실행하기 위해서는 `.env` 파일이 필요합니다. `.env`의 내용은 다음과 같습니다.
 ```env
+REGISTRY=camfia.jfrog.io
 APP_DOMAIN=my-app.com
 LETSENCRYPT_EMAIL=example@email.com
 
@@ -456,7 +459,7 @@ DEV_HOST : my-app-dev.com
 JIRA_BASE_URL : https://my-app.atlassian.net/
 PROD_BASE_URL : https://my-app.com
 PROD_HOST : my-app.com
-REGISTRY : repo.treescale.com
+REGISTRY : camfia.jfrog.io
 REGISTRY_PASSWORD : registrypass
 REGISTRY_USERNAME : registryuser
 SSH_PORT : 22

--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ PROD_BASE_URL : https://my-app.com
 PROD_HOST : my-app.com
 REGISTRY : camfia.jfrog.io
 REGISTRY_PASSWORD : registrypass
+REGISTRY_REPO : repo-name
 REGISTRY_USERNAME : registryuser
 SSH_PORT : 22
 SSH_PRIVATE_KEY : -----BEGIN OPENSSH PRIVATE KEY----- ~~

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - internal_network
 
   backend:
-    image: repo.treescale.com/camfia/backend
+    image: ${REGISTRY}/camfia/backend
     container_name: backend
     volumes:
       - ./log:/log
@@ -44,7 +44,7 @@ services:
       - internal_network
 
   nginx:
-    image: repo.treescale.com/camfia/nginx
+    image: ${REGISTRY}/camfia/nginx
     container_name: nginx
     restart: always
     ports:


### PR DESCRIPTION
container registry 주소를 .env 파일을 통해 동적으로 관리할 수 있도록 수정했다
추가로, secrets에 `REGISTRY`과 `REGISTRY_REPO`를 등록하였다